### PR TITLE
Some more compatibility fixes

### DIFF
--- a/9/platforms/android-9/arch-arm/usr/include/math.h
+++ b/9/platforms/android-9/arch-arm/usr/include/math.h
@@ -523,7 +523,7 @@ double	__builtin_fma(double, double, double) __NDK_FPABI_MATH__;
 double	__builtin_hypot(double, double) __NDK_FPABI_MATH__;
 int	__builtin_ilogb(double) __NDK_FPABI_MATH__ __pure2;
 /* int	__builtin_isinf(double) __NDK_FPABI_MATH__ __pure2; */
-#if !defined(__clang__) || __clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 7)
+#if !defined(__clang__) || __clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 10)
 int	__builtin_isnan(double) __NDK_FPABI_MATH__ __pure2;
 #else
 /* clang < 3.7 has faulty prototype for __builtin_isnan */


### PR DESCRIPTION
This fixes compilation with Clang 3.9 if using older packages
